### PR TITLE
`SepiaEffectManager` now have helpers for dealing with the alpha channel

### DIFF
--- a/Assets/Prefabs/Sepia.prefab
+++ b/Assets/Prefabs/Sepia.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4156527596958341218}
   - component: {fileID: 7049278587779620924}
+  - component: {fileID: 7320535739432947922}
   m_Layer: 0
   m_Name: Sepia
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &7320535739432947922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8122875753041532084}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5dbf2f2fb04ac463f9d8ceed86ff6de4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -177,13 +177,33 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 314457994}
   m_SourcePrefab: {fileID: 100100000, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
 --- !u!4 &223035871 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
   m_PrefabInstance: {fileID: 223035870}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &314457992 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+  m_PrefabInstance: {fileID: 223035870}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &314457994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 314457992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5dbf2f2fb04ac463f9d8ceed86ff6de4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1222214316
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -122,88 +122,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &223035870
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1222214319}
-    m_Modifications:
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      propertyPath: m_Name
-      value: Sepia
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 314457994}
-  m_SourcePrefab: {fileID: 100100000, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
---- !u!4 &223035871 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-  m_PrefabInstance: {fileID: 223035870}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &314457992 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
-  m_PrefabInstance: {fileID: 223035870}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &314457994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 314457992}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5dbf2f2fb04ac463f9d8ceed86ff6de4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1222214316
 GameObject:
   m_ObjectHideFlags: 0
@@ -287,7 +205,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 223035871}
+  - {fileID: 1237477434}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1222214320
@@ -348,6 +266,68 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1001 &1237477433
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1222214319}
+    m_Modifications:
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8122875753041532084, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+      propertyPath: m_Name
+      value: Sepia
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+--- !u!4 &1237477434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4156527596958341218, guid: 8ec02f798b46449a183c1f995641dd45, type: 3}
+  m_PrefabInstance: {fileID: 1237477433}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1396459120
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SepiaEffectManager.cs
+++ b/Assets/Scripts/SepiaEffectManager.cs
@@ -1,21 +1,43 @@
+using System;
 using UnityEngine;
 
 public class SepiaEffectManager : MonoBehaviour
 {
-    public GameObject sepiaElement;
+    private SpriteRenderer _spriteRenderer;
+
+    private void Awake()
+    {
+        _spriteRenderer = GetComponent<SpriteRenderer>();
+
+        if (_spriteRenderer == null)
+        {
+            Debug.Log("Unable to find component sprite renderer for sepia effect manager");
+            return;
+        }
+    }
 
     public void Enable()
     {
-        sepiaElement.SetActive(true);
+        gameObject.SetActive(true);
     }
 
     public void Disable()
     {
-        sepiaElement.SetActive(false);
+        gameObject.SetActive(false);
     }
 
     public void ToggleVisibility()
     {
-        sepiaElement.SetActive(!sepiaElement.activeSelf);
+        gameObject.SetActive(!gameObject.activeSelf);
+    }
+
+    public void SetAlphaChannel(float newAlpha)
+    {
+        _spriteRenderer.color = new Color(
+            _spriteRenderer.color.r,
+            _spriteRenderer.color.g,
+            _spriteRenderer.color.b,
+            newAlpha
+        );
     }
 }


### PR DESCRIPTION
This PR contains a little refactor where now makes the `SepiaEffectManager` intended to be attached to the `Sepia` prefab instead of a standalone script, this will help us with a new feature which allows to set the alpha channel of the sepia effect, allowing us to dynamically set how much the sepia tone should be on runtime, a little example on how we could use it to set the sepia effect alpha during runtime from an arbitrary `MonoBehavior` would be something like this:

```cs
using UnityEngine;

public class MyScript : MonoBehavior
{
    public GameObject sepiaPrefab;
    private SepiaEffectManager _sepiaEffectManager;

    private void Awake()
    {
        _sepiaEffectManager = GetComponent<SepiaEffectManager>();
    }

    private void Update()
    {
        _sepiaEffectManager.Enable();
        _sepiaEffectManager.SetAlphaChannel(0.65);  // set any value from 0-1.
    }
}
```

> [!NOTE]
> These changes have been merged onto testing for reproduciblity reasons.