### PR TITLE
feat: FMOD footsteps with enemies (mostly works with patrol mode)

### DIFF
--- a/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
+++ b/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
@@ -415,6 +415,7 @@ MonoBehaviour:
   MasterBanks:
   - Master
   Banks:
+  - Enemies
   - Player
   BanksToLoad: []
   LiveUpdatePort: 9264

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -500,6 +500,8 @@ GameObject:
   - component: {fileID: 263194355}
   - component: {fileID: 263194354}
   - component: {fileID: 263194359}
+  - component: {fileID: 263194361}
+  - component: {fileID: 263194360}
   m_Layer: 6
   m_Name: Enemy
   m_TagString: Untagged
@@ -550,6 +552,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6a8ea43061ba4c49a7e88130f9b035e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isWaiting: 0
   _movementType: 1
   _patrolPoints:
   - {fileID: 2083476070}
@@ -634,6 +637,53 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &263194360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 263194353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7373e5186335a46fba9d6004f2fef9d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  footstepsEmitter: {fileID: 263194361}
+  _enemyMovement: {fileID: 263194356}
+--- !u!114 &263194361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 263194353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a6610d2e704f1648819acc8d7460285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollisionTag: 
+  EventReference:
+    Guid:
+      Data1: 456378154
+      Data2: 1087474256
+      Data3: 1293115811
+      Data4: 1494154258
+    Path: event:/Footsteps/EnemyFootsteps
+  Event: 
+  EventPlayTrigger: 0
+  EventStopTrigger: 0
+  AllowFadeout: 1
+  TriggerOnce: 0
+  Preload: 0
+  NonRigidbodyVelocity: 0
+  Params:
+  - Name: Parameter 1
+    Value: 0
+  OverrideAttenuation: 0
+  OverrideMinDistance: 1
+  OverrideMaxDistance: 20
 --- !u!1 &302189482
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/EnemyAudioManager.cs
+++ b/Assets/Scripts/Enemy/EnemyAudioManager.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using FMODUnity;
+
+public class EnemyAudioManager : MonoBehaviour
+{
+    public StudioEventEmitter footstepsEmitter;
+    [SerializeField] private EnemyMovement _enemyMovement;
+
+    private void Awake()
+    {
+        if (_enemyMovement == null)
+        {
+            _enemyMovement = GetComponent<EnemyMovement>();
+        }
+    }
+
+    private void Update()
+    {
+        if (IsEnemyMoving() && !footstepsEmitter.IsPlaying())
+        {
+            footstepsEmitter.Play();
+        }
+    }
+
+    // if enemy contains enemymovement script it means it will always be moving prolly
+    private bool IsEnemyMoving()
+    {
+        return _enemyMovement.isWaiting == false;
+    }
+}

--- a/Assets/Scripts/Enemy/EnemyAudioManager.cs.meta
+++ b/Assets/Scripts/Enemy/EnemyAudioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7373e5186335a46fba9d6004f2fef9d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/EnemyMovement.cs
+++ b/Assets/Scripts/Enemy/EnemyMovement.cs
@@ -4,14 +4,15 @@ using UnityEngine;
 public class EnemyMovement : MonoBehaviour
 {
     public enum MovementType { Stationary, Patrol, Chase }
+    public bool isWaiting = false;
+
     [SerializeField] private MovementType _movementType = MovementType.Stationary;
     [SerializeField] private Transform[] _patrolPoints;
     [SerializeField] private float _patrolSpeed = 2f;
     [SerializeField] private float _chaseSpeed = 4f;
     [SerializeField] private Transform _player;
-
-    private int _currentPatrolIndex = 0;
     [SerializeField] private bool _isChasing = false;
+    private int _currentPatrolIndex = 0;
 
     private void Start()
     {
@@ -52,8 +53,11 @@ public class EnemyMovement : MonoBehaviour
             yield return null;
         }
 
+        isWaiting = true;
+
         yield return new WaitForSeconds(2f);
 
+        isWaiting = false;
         _currentPatrolIndex = (_currentPatrolIndex + 1) % _patrolPoints.Length;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Feature

## Description

<!--- Describe your changes in detail -->

This PR expects the `v0.0.3` version of the fmod project, which added the enemy footstep event, this also adds:

1. A new event emitter to the enemy gameobject with the enemy footsteps event
2. A new event audio manager which will trigger the event emitter when the enemy is moving (only tested with the patrol mode)
3. A mechanism to detect if the enemy is waiting for the next point in the patrol mode, see `isWaiting` on `EnemyMovement`.

## Screenshot or Gameplay (if you think is required):

<!--- URL to screenshot or N/A -->

N/A