### PR TITLE
Refactor player movement to move based on recently pressed keys instead of x taking priority over y always

### DIFF
--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -10,9 +10,13 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private SpriteRenderer _sprite;
     [SerializeField] private GameStateManager _state;
 
-    [SerializeField] private bool restrictDiagonalMovement = true; 
+    [SerializeField] private bool restrictDiagonalMovement = true;
 
     private bool _isMoving = false;
+    private float _lastXInputTime;
+    private float _lastYInputTime;
+    private float _prevInputX;
+    private float _prevInputY;
 
     public void HandleMovementInput()
     {
@@ -22,34 +26,44 @@ public class PlayerMovement : MonoBehaviour
         if (_state.duringGameOverSplash || _state.blockControlsRequest)
         {
             _movementInput = Vector2.zero;
+            return;
+        }
+
+        UpdateInputTiming(ref inputX, ref inputY);
+
+        if (restrictDiagonalMovement)
+        {
+            HandlePrioritizedMovement(inputX, inputY);
         }
         else
         {
-            if (restrictDiagonalMovement)
-            {
-                // Prioriza una sola dirección a la vez
-                if (inputX != 0)
-                {
-                    _movementInput = new Vector2(inputX, 0);
-                }
-                else if (inputY != 0)
-                {
-                    _movementInput = new Vector2(0, inputY);
-                }
-                else
-                {
-                    _movementInput = Vector2.zero;
-                }
-            }
-            else
-            {
-                // Movimiento libre, permitiendo diagonales
-                _movementInput = new Vector2(inputX, inputY).normalized;
-            }
+            _movementInput = new Vector2(inputX, inputY).normalized;
         }
 
         Move();
         HandleFlashLightMovement();
+    }
+
+    private void UpdateInputTiming(ref float inputX, ref float inputY)
+    {
+        if (inputX != 0 && _prevInputX == 0) _lastXInputTime = Time.time;
+        if (inputY != 0 && _prevInputY == 0) _lastYInputTime = Time.time;
+
+        _prevInputX = inputX;
+        _prevInputY = inputY;
+    }
+
+    private void HandlePrioritizedMovement(float inputX, float inputY)
+    {
+        if (inputX == 0 || inputY == 0)
+        {
+            _movementInput = new Vector2(inputX, inputY);
+            return;
+        }
+
+        _movementInput = _lastXInputTime > _lastYInputTime
+            ? new Vector2(inputX, 0)
+            : new Vector2(0, inputY);
     }
 
     public void HandleFlashLightMovement()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Refactor

## Description

<!--- Describe your changes in detail -->

This PR refactors a little bit the player movement controller since before, the player keys were having preference over the x axis keys even if the y axis keys were pressed before or later... with these changes, the movement of the player will be something more "easier to use" since now if the player per example, does

- left + right -> Player moves to the right
- up + right -> Player moves to the right
- down + left -> Player moves to the left
- down -> Player moves to the down

So yeah the player moves now by using as priority the last pressed key instead of a fixed priority axis.

## Screenshot or Gameplay (if you think is required):

<!--- URL to screenshot or N/A -->

N/A